### PR TITLE
fix get_ksymaddr

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -4940,7 +4940,7 @@ def parse_address(address):
 def get_ksymaddr(sym):
     # use available symbol
     try:
-        return parse_address(sym)
+        return parse_address('&' + sym)
     except:
         pass
     # use ksymaddr-remote


### PR DESCRIPTION
Should always use '&' to force any kernel variable evaluated as a label (address).

Fixed some static methods in `KernelAddressHeuristicFinder`:
- `get_init_task`
- `get_slab_caches`
- `get_mmap_min_addr`