### PR TITLE
Fix tls for AARCH64 on gdb 14

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -5691,7 +5691,10 @@ class AARCH64(ARM):
     def get_tls(self):
         if is_in_kernel():
             return None
-        return get_register("$TPIDR_EL0")
+        tls = get_register("$TPIDR_EL0")
+        if tls is None:
+            tls = get_register("$tpidr")
+        return tls
 
     def mprotect_asm(self, addr, size, perm):
         _NR_mprotect = 226


### PR DESCRIPTION
Hi
this PR fixes get_tls for native AARCH64, so that it works properly on gdb 14 and avoids a cascading effect preventing heap commands to work properly.