### PR TITLE
Improve the debug output

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -82247,7 +82247,10 @@ class PageMap:
     @staticmethod
     @Cache.cache_until_next
     def get_page_maps_by_pagewalk(command):
-        return gdb.execute(command, to_string=True)
+        res = gdb.execute(command, to_string=True)
+        if 'Exception raised' in res:
+            gef_print(res)
+        return res
 
     @staticmethod
     @Cache.cache_until_next


### PR DESCRIPTION
After changing the Linux kernel security parameters on my system, this tool has broken.

For example:
```
gef> ksymaddr-remote -r
[+] Wait for memory scan
[*] Make sure you are in ring0 (=kernel mode)
[+] Try to re-parse (ignore cached config)
[+] Failed to parse
```

It took me some time to debug this and find out the real reason: setting sysctl `kernel.yama.ptrace_scope` to non-zero value breaks the `pagewalk` command that depends on reading `/proc/pid/mem`.

Let's improve the debug output. This would allow to detect the problem immediately:
```
gef> ksymaddr-remote -r
[+] Wait for memory scan

------------------------------- Exception raised -------------------------------
PermissionError: [Errno 13] Отказано в доступе: '/proc/24150/mem'
----------------------------- Detailed stacktrace ------------------------------
...
--------------------------------------------------------------------------------

[*] Make sure you are in ring0 (=kernel mode)
[+] Try to re-parse (ignore cached config)
[+] Failed to parse
```