### PR TITLE
fix is_valid_addr

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -11102,9 +11102,10 @@ def write_physmem(paddr, data):
 
 @Cache.cache_until_next
 def is_valid_addr(addr):
-    if not isinstance(addr, int):
+    if not hasattr(addr, "__int__"):
         return False
 
+    addr = int(addr)
     if addr < 0:
         return False
 


### PR DESCRIPTION
If gdb.Value is passed as input to is_valid_addr, it will always fail.

```
gef> gef version --compact
gdb:     16.2
python:  3.13.2 (main, Feb  5 2025, 08:05:21) [GCC 14.2.1 20250128]
OS:      \S{PRETTY_NAME} \r (\l)
kernel:  Linux laptop 6.13.8-arch1-1 #1 SMP PREEMPT_DYNAMIC Sun, 23 Mar 2025 17:17:30 +0000 x86_64 GNU/Linux
gef> pi isinstance(gdb.Value(0), int)
False
gef> p $rsp
$1 = (void *) 0x7fffffffdf60
gef> der 0x7fffffffdf60 -n 1
$rsp  0x7fffffffdf60|+0x0000|+000: 0x00007fffffffdfb0  ->  0x00007fffffffdfe0  ->  0x00007fffffffe2e0  ->  ...
gef> pi is_valid_addr(0x7fffffffdf60)
True
gef> pi is_valid_addr(gdb.Value(0x7fffffffdf60))
False
```

For example, in `GlibcHeap.search_for_main_arena_from_tls`, passing a variable of type gdb.Value as an argument to `is_valid_addr` always causes the search for main_arena to fail
```python
    @staticmethod
    @Cache.cache_until_next
    def search_for_main_arena_from_tls():
        # ... 
        for i in range(1, 500):
            addr = tls + (current_arch.ptrsize * i) * direction

            if is_m68k():
                addr += 2

            if not is_valid_addr(addr):
                break

            candidate_arena_addr = read_int_from_memory(addr)
            if not is_valid_addr(candidate_arena_addr):
                continue

            candidate_arena = GlibcHeap.MallocStateStruct(candidate_arena_addr)
            system_mem = candidate_arena.system_mem
            if system_mem < gef_getpagesize():
                continue

            top = candidate_arena.top # <= type(candidate_arena.top) == gdb.Value
            if not is_valid_addr(top):
                continue

            # ...
```

I think it would be a good idea to check if the `__int__` function can be used