### PR TITLE
fix kchecksec: implementation of userfaultfd

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -24947,30 +24947,32 @@ class KernelChecksecCommand(GenericCommand):
     def check_unprivileged_userfaultfd(self):
         cfg = "vm.unprivileged_userfaultfd"
         kversion = Kernel.kernel_version()
-        if kversion < "5.2":
-            additional = "{:s}: implemented from linux 5.2".format(cfg)
-            gef_print("{:<40s}: {:s} ({:s})".format(cfg, Color.colorify("Unimplemented", "bold red"), additional))
-            return
-
-        stv_uff_ret = gdb.execute("syscall-table-view -f userfaultfd --quiet --no-pager", to_string=True)
-        if "userfaultfd" not in stv_uff_ret:
-            additional = "userfaultfd syscall: Unimplemented"
-            gef_print("{:<40s}: {:s} ({:s})".format(cfg, Color.colorify("Syscall unsupported", "bold green"), additional))
-        elif "invalid userfaultfd" in stv_uff_ret:
-            additional = "userfaultfd syscall: Disabled"
-            gef_print("{:<40s}: {:s} ({:s})".format(cfg, Color.colorify("Syscall unsupported", "bold green"), additional))
-        else:
-            sysctl_unprivileged_userfaultfd = KernelAddressHeuristicFinder.get_sysctl_unprivileged_userfaultfd()
-            if sysctl_unprivileged_userfaultfd is None:
-                additional = "{:s}: Not found".format(cfg)
-                gef_print("{:<40s}: {:s} ({:s})".format(cfg, Color.grayify("Unknown"), additional))
+        if kversion >= "4.3":
+            stv_uff_ret = gdb.execute("syscall-table-view -f userfaultfd --quiet --no-pager", to_string=True)
+            if "userfaultfd" not in stv_uff_ret:
+                additional = "userfaultfd syscall: Unimplemented"
+                gef_print("{:<40s}: {:s} ({:s})".format(cfg, Color.colorify("Syscall unsupported", "bold green"), additional))
+            elif "invalid userfaultfd" in stv_uff_ret:
+                additional = "userfaultfd syscall: Disabled"
+                gef_print("{:<40s}: {:s} ({:s})".format(cfg, Color.colorify("Syscall unsupported", "bold green"), additional))
+            elif kversion < "5.2":
+                additional = "userfaultfd syscall: Enabled, but without vm.unprivileged_userfaultfd restriction! (implemented from linux 5.2)"
+                gef_print("{:<40s}: {:s} ({:s})".format(cfg, Color.colorify("Syscall supported", "bold green"), additional))
             else:
-                v = u32(read_memory(sysctl_unprivileged_userfaultfd, 4))
-                additional = "{:s}: {:d}".format(cfg, v)
-                if v == 0:
-                    gef_print("{:<40s}: {:s} ({:s})".format(cfg, Color.colorify("Disabled", "bold green"), additional))
+                sysctl_unprivileged_userfaultfd = KernelAddressHeuristicFinder.get_sysctl_unprivileged_userfaultfd()
+                if sysctl_unprivileged_userfaultfd is None:
+                    additional = "{:s}: Not found".format(cfg)
+                    gef_print("{:<40s}: {:s} ({:s})".format(cfg, Color.grayify("Unknown"), additional))
                 else:
-                    gef_print("{:<40s}: {:s} ({:s})".format(cfg, Color.colorify("Enabled", "bold red"), additional))
+                    v = u32(read_memory(sysctl_unprivileged_userfaultfd, 4))
+                    additional = "{:s}: {:d}".format(cfg, v)
+                    if v == 0:
+                        gef_print("{:<40s}: {:s} ({:s})".format(cfg, Color.colorify("Disabled", "bold green"), additional))
+                    else:
+                        gef_print("{:<40s}: {:s} ({:s})".format(cfg, Color.colorify("Enabled", "bold red"), additional))
+        else:
+            additional = "userfaultfd syscall: implemented from linux 4.3".format(cfg)
+            gef_print("{:<40s}: {:s} ({:s})".format(cfg, Color.colorify("Unsupported", "bold red"), additional))
         return
 
     def check_unprivileged_bpf_disabled(self):


### PR DESCRIPTION
in `kchecksec` function specifically check at userfaultfd implementation for unprivileged usage, it is better not determine via “vm.unprivileged_userfaultfd” sysctl knob but rather the version first. this is based on when the userfaultfd() system call is introduced by the kernel in version 4.3 which is in default state it's already for unprivileged usage.

another backed idea is using ctf chall for case example, in `kstack` from `seccon 2020`. it's using old kernel v4.19.98 but the intended solution is using userfaultfd and doesn't have the “vm.unprivileged_userfaultfd” sysctl knob. notice in the image below it's only check for the sysctl knob implementation

![Screenshot 2025-04-16 184005](https://github.com/user-attachments/assets/76765087-f128-4cff-b493-c071261732fc)

so here i propose the way it check the userfaultfd system call
- check if the kernel version >= 4.3 &  < 5.2, then we are following the same pattern as sysctl knob check.
- i notice you put the 5.2 version check at the beginning of function `check_unprivileged_userfaultfd()`, so to avoid some kind of bad implementation i remove it and more focused on the version check of 4.3 

here below is the patched version
![image](https://github.com/user-attachments/assets/c6a88e13-7d60-4aa3-a43d-e0d67cb44d74)

sorry if there's any mistake on my implementation, I'll be open for discussion because this implementation is only useful for ctf player that wanna learn the technique in old kernel version

- link
https://kernelnewbies.org/Linux_4.3 (added userfaultfd system call)
https://bbs.archlinux.org/viewtopic.php?id=249630 (added sysctl knob)
https://ptr-yudai.hatenablog.com/entry/2020/10/11/213127 (old kernel chall which doesn't have sysctl knob)