### PR TITLE
Update install-uv.sh

### DIFF
--- a/install-uv.sh
+++ b/install-uv.sh
@@ -34,6 +34,10 @@ apt-get install -y gdb-multiarch wget
 apt-get install -y binutils python3-dev gcc make ruby-dev git file colordiff imagemagick
 apt-get install -y binwalk
 
+echo "[+] Installing rust"
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+
 echo "[+] Install uv"
 if [ -z "$(command -v uv)" ]; then
     wget -qO- https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
Rust must be installed as a dependency to build angr

This will fix the following error:
```shell
Using Python 3.12.3 environment at: /root/.gef/.venv-gef
Resolved 40 packages in 9ms
  × Failed to build `angr==9.2.157`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)

      [stdout]
      running bdist_wheel
      running build
      Building angr_native
      gmake: Nothing to be done for 'all'.
      running build_py
      copying angr/sim_variable.py -> build/lib.linux-x86_64-cpython-312/angr
      ...
      ...
      ...
      copying angr/procedures/definitions/win32_api-ms-win-wsl-api-l1-1-0.py -> build/lib.linux-x86_64-cpython-312/angr/procedures/definitions
      running build_ext
      running build_rust

      [stderr]
      /root/.cache/uv/builds-v0/.tmpvRF5FO/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
      !!

              ********************************************************************************
              Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

              By 2026-Feb-18, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************

      !!
        corresp(dist, value, root_dir)
      /root/.cache/uv/builds-v0/.tmpvRF5FO/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:55: SetuptoolsDeprecationWarning: 'tool.setuptools.license-files' is deprecated in favor of
      'project.license-files' (available on setuptools>=77.0.0).
      !!

              ********************************************************************************

              By 2026-Feb-18, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-files for details.
              ********************************************************************************

      !!
        _apply_tool_table(dist, config, filename)
      /root/.cache/uv/builds-v0/.tmpvRF5FO/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!

              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:

              License :: OSI Approved :: BSD License

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************

      !!
        dist._finalize_license_expression()
      /root/.cache/uv/builds-v0/.tmpvRF5FO/lib/python3.12/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!

              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:

              License :: OSI Approved :: BSD License

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************

      !!
        self._finalize_license_expression()
      /root/.cache/uv/builds-v0/.tmpvRF5FO/lib/python3.12/site-packages/setuptools/command/build_py.py:212: _Warning: Package 'angr.lib' is absent from the `packages` configuration.
      !!

              ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'angr.lib' as an importable package[^1],
              but it is absent from setuptools' `packages` configuration.

              This leads to an ambiguous overall configuration. If you want to distribute this
              package, please make sure that 'angr.lib' is explicitly added
              to the `packages` configuration field.

              Alternatively, you can also rely on setuptools' discovery methods
              (for example by using `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).

              You can read more about "package discovery" on setuptools documentation page:

              - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

              If you don't want 'angr.lib' to be distributed and are
              already explicitly excluding 'angr.lib' via
              `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or `include-package-data=False` in
              combination with a more fine grained `package-data` configuration.

              You can read more about "package data files" on setuptools documentation page:

              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


              [^1]: For Python, any directory (with suitable naming) can be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of package data
                    directory, all directories are treated like packages.
              ********************************************************************************

      !!
        check.warn(importable)
      error: can't find Rust compiler

      If you are using an outdated pip version, it is possible a prebuilt wheel is available for this package but pip is not able to install from it. Installing from the wheel would avoid the need for a
      Rust compiler.

      To update pip, run:

          pip install --upgrade pip

      and then retry package installation.

      If you did intend to build this package from source, try installing a Rust compiler from your system package manager and ensure it is on the PATH during installation. Alternatively, rustup (available
      at https://rustup.rs) is the recommended way to download and update the Rust compiler toolchain.

      hint: This usually indicates a problem with the package or the build environment.
```