### PR TITLE
fix: kmem-cache-alias throws UnboundLocalError when no cache matches …

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -77167,6 +77167,7 @@ class KmemCacheAliasCommand(GenericCommand, BufferingOutput):
         else:
             sorted_alias_groups = sorted(alias_groups.items())
 
+        found = False
         # print
         for name, v in sorted_alias_groups:
             # filtering by name


### PR DESCRIPTION
### Describe the bug
Hello, When running kmem-cache-alias with name filters, if no cache matches the filter, GEF raises an exception instead of showing a "not found" message.

### Error message

UnboundLocalError: local variable 'found' referenced before assignment

<img width="990" height="732" alt="Image" src="https://github.com/user-attachments/assets/a0a2b5a0-7523-42b6-9a47-e025fdbf2af4" />

### Steps to reproduce

- Run kmem-cache-alias some_nonexistent_name

- GEF throws an exception

### Expected behavior
GEF should print something like:
```bash
No caches found matching filters
```
instead of raising an exception.