### PR TITLE
Incorrect detection of kallsyms_token_table when stray valid characters appear before the actual table

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -81407,21 +81407,32 @@ class KsymaddrRemoteCommand(GenericCommand, BufferingOutput):
         self.verbose_info("unique_bytes: {:#x}".format(self.ro_base + position))
 
         # second, backward search for the top
-        prev_x = None
-        while True:
-            position -= 1
-            if position < 0:
-                self.verbose_err("Could not find kallsyms_token_table (failed to get top)")
-                return False
-            x = self.kernel_img[position:position + 1]
-            if x not in b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.$@\0":
-                break
-            if x == prev_x == b"\0": # \0\0 is inappropriate
-                break
-            prev_x = x
+        position -= 1
+        if position < 0:
+            self.verbose_err("Could not find kallsyms_token_table (failed to get top: before '0')")
+            return False
+        if self.kernel_img[position] != 0:
+            self.verbose_err("Unexpected byte before '0' entry in kallsyms_token_table")
+            return False
+        num_tokens_back = ord('0')  # 48
+        max_token_len = 50
+        for _ in range(num_tokens_back):
+            for chars_in_token_backwards in range(max_token_len):
+                position -= 1
+                if position < 0:
+                    self.verbose_err("Could not find kallsyms_token_table (out of range while walking tokens)")
+                    return False
 
+                b = self.kernel_img[position]
+                if b == 0 or b > ord('z'):
+                    break
+
+                if chars_in_token_backwards >= max_token_len - 1:
+                    self.verbose_err("This structure is not a kallsyms_token_table (token too long)")
+                    return False
         position += 1
-        position += -position % 4
+        position += -position % 4 
+
         self.offset_kallsyms_token_table = position
         self.save_config("offset_kallsyms_token_table")
         self.verbose_info("kallsyms_token_table: {:#x}".format(self.ro_base + self.offset_kallsyms_token_table))


### PR DESCRIPTION
Hi,
While debugging the Linux kernel (version [lts-6.12.46](https://storage.googleapis.com/kernelctf-build/releases/lts-6.12.46/vmlinux.gz)), I encountered the following error:
```bash
Could not find kallsyms_token_index (0 candidate)
```
After investigation, it appears the issue is caused by an incorrect detection of the kallsyms_token_table start address.

## Description
In certain kernel builds, the current implementation of find_kallsyms_token_table() incorrectly detects the start offset of the kallsyms_token_table.
This happens when there are accidental valid characters immediately preceding the real token table.

For example, in a specific kernel image, the correct start of the token table is:
```bash
0xffffffff8338c430:
    54 52 41 43 00 45 5f 53 59 00 66 6f 00 ...
    TRAC\0E_SY\0fo\0...
```
However, the function incorrectly identifies:
```bash
0xffffffff8338c42c:
    72 4a 38 00 54 52 41 43 ...
    rJ8\0TRAC...
```
The sequence rJ8\0 consists entirely of characters currently considered “valid”, so the backward scanning logic incorrectly walks past the true table boundary.

As a result, the detected offset is off by 4 bytes.

## Expected Behavior
The backward search should never absorb unrelated preceding strings.
It should reliably stop at the true beginning of the 0th token in kallsyms_token_table.

## Proposed Minimal Fix (Token-based backward traversal)
Instead of relying solely on “character validity” while scanning backward, the parser should use the structure of the token table itself.
Reference:
https://github.com/marin-m/vmlinux-to-elf/blob/180f236ae4da09eba6627400810d704f9f8ef131/vmlinux_to_elf/core/kallsyms.py#L393

### Step 1
Locate the "0\0 1\0 ... 9\0" entry (token index = ASCII '0' = 48).

### Step 2
Move backward exactly 48 tokens to reach token index 0.

### Step 3
Each token is defined as:
- A sequence of characters [A-Za-z0-9_.$]
- Ending with \0
- Max length ~50 bytes (consistent with kernel scripts)

This token-aware traversal guarantees correct boundaries even if garbage or valid strings appear before the table.