### PR TITLE
fix: a hacky buffer overflow disrupting debugging on Python 3.14

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -107780,7 +107780,8 @@ class GefUtil:
 
         TIOCGWINSZ = 0x5413
         try:
-            tty_rows, tty_columns = struct.unpack("hh", fcntl.ioctl(1, TIOCGWINSZ, "1234"))
+            _ws = struct.unpack("HHHH", fcntl.ioctl(1, TIOCGWINSZ, b"12345678"))
+            tty_rows, tty_columns = _ws[0], _ws[1]
             return tty_rows, tty_columns
         except OSError:
             return 600, 100


### PR DESCRIPTION
Otherwise it won't be working properly on Python 3.14. It solves the following issue:

```
------------------------------- Exception raised -------------------------------

SystemError: buffer overflow

----------------------------- Detailed stacktrace ------------------------------

File "/home/raindrop/.gef.py", line 107783, in get_terminal_size()
   ->     tty_rows, tty_columns = struct.unpack("hh", fcntl.ioctl(1, TIOCGWINSZ, "1234"))
File "/home/raindrop/.gef.py", line 29615, in context_title()
   ->     _, tty_columns = GefUtil.get_terminal_size(redirect=redirect)
File "/home/raindrop/.gef.py", line 29771, in do_invoke()
   ->     ContextCommand.context_title("", redirect)
File "/home/raindrop/.gef.py", line 11673, in wrapper()
   ->     return f(self, args, **kwargs)
File "/home/raindrop/.gef.py", line 14209, in invoke()
   ->     self.do_invoke(argv)

----------------------------- Runtime environment ------------------------------

gdb:     16.3-6.fc43
python:  3.14.2 (main, Dec  5 2025, 00:00:00) [GCC 15.2.1 20251111 (Red Hat 15.2.1-4)]
OS:      Fedora Linux 43 (KDE Plasma Desktop Edition)
kernel:  Linux ---- #1 SMP PREEMPT_DYNAMIC Mon Oct  6 15:37:21 UTC 2025 x86_64 GNU/Linux

--------------------------------------------------------------------------------
```