### PR TITLE
Support slub-dump in KGDB mode

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -75673,12 +75673,17 @@ class SlubDumpCommand(GenericCommand, BufferingOutput):
 
     @parse_args
     @only_if_gdb_running
-    @only_if_specific_gdb_mode(mode=("qemu-system", "vmware"))
+    @only_if_specific_gdb_mode(mode=("qemu-system", "vmware", "kgdb"))
     @only_if_specific_arch(arch=("x86_32", "x86_64", "ARM32", "ARM64"))
     @only_if_in_kernel_or_kpti_disabled
     def do_invoke(self, args):
         if args.help_for_slab_virtual:
             gef_print(self._note2_.strip())
+            return
+
+        # slub-dump depends on page2virt, which requires access to system registers.
+        if is_kgdb() and not kgdb_has_system_registers():
+            err("Unsupported in kgdb mode without access to system registers")
             return
 
         self.quiet_info("Wait for memory scan")
@@ -100623,11 +100628,16 @@ class PageCommand(GenericCommand):
 
     @parse_args
     @only_if_gdb_running
-    @only_if_specific_gdb_mode(mode=("qemu-system", "vmware"))
+    @only_if_specific_gdb_mode(mode=("qemu-system", "vmware", "kgdb"))
     @only_if_specific_arch(arch=("x86_64", "x86_32", "ARM64", "ARM32"))
     @only_if_in_kernel
     def do_invoke(self, args):
-        info("Wait for memory scan")
+        if is_kgdb():
+            if self.args.mode == "to_phys" or self.args.mode == "from_phys":
+                err("Unsupported in kgdb mode")
+            elif self.args.mode == "to_virt" or self.args.mode == "from_virt" and \
+                    not kgdb_has_system_registers():
+                err("Unsupported in kgdb mode without access to system registers")
 
         if not hasattr(self, "initialized"):
             self.initialized = False
@@ -100640,6 +100650,8 @@ class PageCommand(GenericCommand):
             if kversion < "4.7":
                 err("Unsupported before v4.7")
                 return
+
+        info("Wait for memory scan")
 
         ret = self.initialize()
         if ret is False:
@@ -100668,10 +100680,13 @@ class Page2VirtCommand(GenericCommand):
 
     @parse_args
     @only_if_gdb_running
-    @only_if_specific_gdb_mode(mode=("qemu-system", "vmware"))
+    @only_if_specific_gdb_mode(mode=("qemu-system", "vmware", "kgdb"))
     @only_if_specific_arch(arch=("x86_64", "x86_32", "ARM64", "ARM32"))
     @only_if_in_kernel
     def do_invoke(self, args):
+        if is_kgdb() and not kgdb_has_system_registers():
+            err("Unsupported in kgdb mode without access to system registers")
+            return
         rstr = "-r" if args.rescan else ""
         gdb.execute("page to_virt {:s} {:#x}".format(rstr, args.page))
         return
@@ -100692,10 +100707,13 @@ class Virt2PageCommand(GenericCommand):
 
     @parse_args
     @only_if_gdb_running
-    @only_if_specific_gdb_mode(mode=("qemu-system", "vmware"))
+    @only_if_specific_gdb_mode(mode=("qemu-system", "vmware", "kgdb"))
     @only_if_specific_arch(arch=("x86_64", "x86_32", "ARM64", "ARM32"))
     @only_if_in_kernel
     def do_invoke(self, args):
+        if is_kgdb() and not kgdb_has_system_registers():
+            err("Unsupported in kgdb mode without access to system registers")
+            return
         rstr = "-r" if args.rescan else ""
         gdb.execute("page from_virt {:s} {:#x}".format(rstr, args.virt))
         return


### PR DESCRIPTION
Allow `slub-dump` to be used, assuming KGDB provides access to system registers.

As `slub-dump` internally uses `page to_virt`, also allow this command along with `page from_virt`.

`page to/from_phys` are not allowed yet (one of them relies on `gva2gpa`, the other I have not yet tested). It might be possible to provide support for these along with the solution for #158.