### PR TITLE
Fix pageinfo for kversion < 6.12

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -151206,8 +151206,19 @@ class PageInfoCommand(GenericCommand):
 
     def get_slot6_kind(self, slot6_raw):
         slot6_s32 = self.u32_to_s32(slot6_raw)
-        pgty_mapcount_underflow_shifted = self.u32_to_s32(0xff << 24)
-        if slot6_s32 < pgty_mapcount_underflow_shifted:
+        kversion = Kernel.kernel_version()
+
+        if kversion >= "6.12":
+            pgty_mapcount_underflow_shifted = self.u32_to_s32(0xff << 24)
+            has_type = slot6_s32 < pgty_mapcount_underflow_shifted
+        elif  kversion >= "6.11":
+            page_mapcount_reserve = self.u32_to_s32(0xffff0000) 
+            has_type = slot6_s32 < page_mapcount_reserve
+        else:
+            page_mapcount_reserve = -128
+            has_type = slot6_s32 < page_mapcount_reserve
+
+        if has_type:
             return "type"
         return "mapcount"
 


### PR DESCRIPTION
`pageinfo` command misclassifies page_type as mapcount on kernel version < 6.12

```
------------------------------------------------------------------------- free_area -------------------------------------------------------------------------
order: 0 (0x1000 bytes)                                                                                                                                     
  mtype: 0 (=Unmovable)
    page:0xffffd8c940004040  size:0x001000  virt:0xffff9e5440101000-0xffff9e5440102000  phys:0x0000000000101000-0x0000000000102000
...

gef> kversion
[+] Wait for memory scan
0xffffffffa7c00100: Linux version 6.6.32 ... 
gef> pageinfo -p 0xffffd8c940004040
Page            : 0xffffd8c940004040
Direct-map virt : 0xffff9e5440101000
flags           : 0x0000000000000000 (none)
is_tailpage     : False
slot6_kind      : mapcount
  mapcountraw        : 0xffffff7f
  userspace_mapped   : False
  userspace_mapcount : 0x0
in_buddy_list   : False
  free_status        : unknown (PCP free pages are not checked)
```

I believe this is due to the way `slot6_kind` is computed.

```python
    def get_slot6_kind(self, slot6_raw):
        slot6_s32 = self.u32_to_s32(slot6_raw)
        pgty_mapcount_underflow_shifted = self.u32_to_s32(0xff << 24)
        if slot6_s32 < pgty_mapcount_underflow_shifted:
            return "type"
        return "mapcount"
```
This function mimics `page_type_has_type` and it is correct for kernels 6.12+ however this function was different before this version.
on 6.11: https://elixir.bootlin.com/linux/v6.11/source/include/linux/page-flags.h#L954
before 6.11: https://elixir.bootlin.com/linux/v6.10/source/include/linux/page-flags.h#L957

Under is the output of `pageinfo` after the patch on the same `page`

```
gef> pageinfo -p 0xffffd8c940004040
Page            : 0xffffd8c940004040
Direct-map virt : 0xffff9e5440101000
flags           : 0x0000000000000000 (none)
is_tailpage     : False
slot6_kind      : type
  page_type          : 0xffffff7f (PG_buddy)
  userspace_mapped   : N/A
  userspace_mapcount : N/A
in_buddy_list   : True
refcount        : 0x0
```
