### PR TITLE
Add buddy-contains

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -127466,7 +127466,7 @@ class BuddyContainsCommand(BuddyDumpCommand):
         else:
             virt = Kernel.page2virt(page)
             offset = virt & get_pagesize_mask_low()
-        
+
         phys = self.page2phys_wrapper(page)
 
         if phys is None:
@@ -127513,14 +127513,14 @@ class BuddyContainsCommand(BuddyDumpCommand):
         freed_address_color = Config.get_gef_setting("theme.heap_chunk_address_freed")
         PAGE_SIZE = KernelAddressHeuristicFinder.consts().PAGE_SIZE
         PAGE_SHIFT = KernelAddressHeuristicFinder.consts().PAGE_SHIFT
- 
+
         size = PAGE_SIZE << order
         head_phys = head_pfn << PAGE_SHIFT
         head_virt = Kernel.page2virt(head_page)
- 
+
         page_str = Color.colorify("{:#x}".format(head_page), freed_address_color)
         size_str = Color.colorify_hex(size, chunk_size_color)
- 
+
         gef_print("order: {:d} ({:#x} bytes, {:d} pages)".format(order, size, 1 << order))
         if head_virt is not None:
             virt_str = "{:#x}-{:#x}".format(head_virt, head_virt + size)
@@ -127542,7 +127542,7 @@ class BuddyContainsCommand(BuddyDumpCommand):
         self.quiet_print("phys: {:#x} (pfn: {:#x})".format(phys, pfn))
         if offset_in_page:
             self.quiet_print("remarks: {:s} to page (offset: +{:#x})".format(Color.redify("unaligned"), offset_in_page,))
-        
+
         if self.is_page_buddy(page):
             head_page = page
             head_pfn = pfn
@@ -127556,7 +127556,7 @@ class BuddyContainsCommand(BuddyDumpCommand):
                 Color.colorify("unknown", used_address_color),
             ))
             gef_print("remarks: no PG_buddy head page found, run buddy-contains without skipping free lists.")
- 
+
         # Part of a larger block
         elif head_page != page:
             self.quiet_print("status: {:s}".format(
@@ -127581,7 +127581,7 @@ class BuddyContainsCommand(BuddyDumpCommand):
             BuddyDumpCommand.maps = PageMap.get_page_maps(None)
             if BuddyDumpCommand.maps is None:
                 return None
- 
+
         node_entries = []
         tqdm = GefUtil.get_tqdm(not self.args.quiet)
         for i, node in tqdm(enumerate(self.nodes), leave=False, total=len(self.nodes), desc="node"):
@@ -127596,7 +127596,7 @@ class BuddyContainsCommand(BuddyDumpCommand):
                 return False
             npages = entry.size // KernelAddressHeuristicFinder.consts().PAGE_SIZE
             return entry.page <= page < entry.page + npages * self.sizeof_struct_page
- 
+
         for node_title, zone_entries in node_entries:
             for zone_title, zone_entry in zone_entries:
                 if "per_cpu_pageset" in zone_entry:
@@ -127615,8 +127615,8 @@ class BuddyContainsCommand(BuddyDumpCommand):
                                         "sub_title": "cpu: {:d}".format(cpu_num),
                                         "list_title": pcp_title,
                                     }
-                                    
- 
+
+
                 if "free_area" in zone_entry:
                     for order_title, free_lists, has_any in zone_entry["free_area"]:
                         if not has_any:
@@ -127681,7 +127681,7 @@ class BuddyContainsCommand(BuddyDumpCommand):
         else:
             page = self.get_page()
             if page is None:
-                return 
+                return
             self.parse_free_lists(page)
 
         return
@@ -127697,7 +127697,7 @@ class BuddyContainsCommand(BuddyDumpCommand):
         if self.args.skip_free_list and kversion < "4.18":
             self.quiet_err("Unsupported before v4.18")
             return
-        
+
         if kversion < "3.1":
             self.quiet_err("Unsupported before v3.1")
             return
@@ -127719,15 +127719,15 @@ class BuddyContainsCommand(BuddyDumpCommand):
         if not self.initialize():
             self.quiet_err("Failed to initialize")
             return
- 
+
         self.sizeof_struct_page = KernelAddressHeuristicFinder.consts().sizeof_struct_page
-        if self.sizeof_struct_page is None: 
+        if self.sizeof_struct_page is None:
             self.quiet_err("Could not find sizeof(struct page)")
-            return 
+            return
 
         self.buddy_contains()
         return
- 
+
 @register_command
 class KernelPipeCommand(GenericCommand, BufferingOutput):
     """Dump pipe information."""
@@ -151564,7 +151564,7 @@ class PageInfoCommand(GenericCommand):
             pgty_mapcount_underflow_shifted = PageInfoCommand.u32_to_s32(0xff << 24)
             has_type = slot6_s32 < pgty_mapcount_underflow_shifted
         elif  kversion >= "6.11":
-            page_mapcount_reserve = PageInfoCommand.u32_to_s32(0xffff0000) 
+            page_mapcount_reserve = PageInfoCommand.u32_to_s32(0xffff0000)
             has_type = slot6_s32 < page_mapcount_reserve
         else:
             page_mapcount_reserve = -128

--- a/gef.py
+++ b/gef.py
@@ -127377,7 +127377,229 @@ class BuddyDumpCommand(GenericCommand, BufferingOutput):
         self.print_output(check_terminal_size=True)
         return
 
+@register_command
+class BuddyContainsCommand(BuddyDumpCommand):
+    """Resolves which buddy block an address belongs to."""
+    _cmdline_ = "buddy-contains"
+    _category_ = "06-h. Qemu-system/KGDB Cooperation - Linux Allocator"
+    _aliases_ = []
 
+    parser = argparse.ArgumentParser(prog=_cmdline_)
+    parser.add_argument("address", metavar="ADDRESS", type=AddressUtil.parse_address, help="target address.")
+    parser.add_argument("-p", "--page", action="store_true",
+                        help="interpret ADDRESS as a `struct page` address instead of a virtual address.")
+    parser.add_argument("--MIGRATE_PCPTYPES", type=int, choices=[3, 4], default=3,
+                        help="use specify value; linux: 3, android: 4 (2023~).")
+    parser.add_argument("-r", "--rescan", action="store_true", help="do not use cache.")
+    parser.add_argument("-v", "--verbose", action="store_true", help="enable verbose mode.")
+    parser.add_argument("-q", "--quiet", action="store_true", help="show result only.")
+    _syntax_ = parser.format_help()
+
+    _example_ = [
+        "{0:s} 0xffff888003c01234",
+        "{0:s} -p 0xffffea00000f0040    # ADDRESS is a `struct page`",
+    ]
+    _example_ = "\n".join(_example_).format(_cmdline_)
+    
+    _note_ = "TEST BUDDY CONTAINS"
+
+    def fill_dump_args(self):
+        self.args.zone_filter = None
+        self.args.order_filter = None
+        self.args.mtype_filter = None
+        self.args.pcp_index_filter = None
+        self.args.cpu = None
+        self.args.only_pcp = False
+        self.args.skip_pcp = False
+        self.args.sort = False
+        self.args.sort_verbose = False
+        self.args.vverbose = False
+        self.args.count = 0
+        return
+
+    def page2phys_wrapper(self, page):
+        ret = gdb.execute("page2phys {:#x}".format(page), to_string=True)
+        r = re.search(r"Phys: (\S+)", ret)
+        if r:
+            return int(r.group(1), 16)
+        return None
+
+    def resolve_target(self):
+        if self.args.page:
+            page = self.args.address
+            if not is_valid_addr(page):
+                self.quiet_err("Invalid page address")
+                return None
+            virt = Kernel.page2virt(page)
+            offset = 0
+        else:
+            virt = self.args.address
+            page = Kernel.virt2page(virt & get_pagesize_mask_high())
+            if page is None:
+                self.quiet_err("Failed to resolve page from virt")
+                return None
+            offset = virt & get_pagesize_mask_low()
+        
+        phys = self.page2phys_wrapper(page)
+
+        if phys is None:
+            self.quiet_err("Failed to resolve phys from page")
+            return None
+
+        return page, virt, phys, offset
+
+    def get_buddy_order(self, page):
+        try:
+            order = read_int_from_memory(page + current_arch.ptrsize * 5)
+        except gdb.MemoryError:
+            return None
+        if order >= self.MAX_ORDER:
+            return None
+        return order
+
+    def is_page_buddy(self, page):
+        try:
+            slot6_raw = read_int32_from_memory(page + current_arch.ptrsize * 6)
+        except gdb.MemoryError:
+            return False
+        slot6_kind = PageInfoCommand.get_slot6_kind(slot6_raw)
+        return PageInfoCommand.is_buddy_free(slot6_raw, slot6_kind)
+
+    def find_head_page(self, page, pfn):
+        for order in range(self.MAX_ORDER):
+            # Go back order by order to find the head or not if the page is not in the buddy
+            head_pfn = pfn & ~((1 << order) - 1)
+            head_page = page - (pfn - head_pfn) * self.sizeof_struct_page
+
+            # Just for good measures 
+            if not is_valid_addr(head_page):
+                continue
+            if not self.is_page_buddy(head_page):
+                continue
+            if self.get_buddy_order(head_page) != order:
+                continue
+            return head_page, head_pfn, order
+        return None, None, None
+
+    def print_block_info(self, page, pfn, head_page, head_pfn, order):
+        """Print the block a page belongs to, following buddy-dump's Entry style."""
+        chunk_size_color = Config.get_gef_setting("theme.heap_chunk_size")
+        freed_address_color = Config.get_gef_setting("theme.heap_chunk_address_freed")
+        PAGE_SIZE = KernelAddressHeuristicFinder.consts().PAGE_SIZE
+        PAGE_SHIFT = KernelAddressHeuristicFinder.consts().PAGE_SHIFT
+ 
+        size = PAGE_SIZE << order
+        head_phys = head_pfn << PAGE_SHIFT
+        head_virt = Kernel.page2virt(head_page)
+ 
+        page_str = Color.colorify("{:#x}".format(head_page), freed_address_color)
+        size_str = Color.colorify_hex(size, chunk_size_color)
+ 
+        gef_print("order: {:d} ({:#x} bytes, {:d} pages)".format(order, size, 1 << order))
+        if head_virt is not None:
+            virt_str = "{:#x}-{:#x}".format(head_virt, head_virt + size)
+        else:
+            virt_str = "(no direct map)"
+        phys_str = "{:#x}-{:#x}".format(head_phys, head_phys + size)
+        gef_print("    page:{:s}  size:{:s}  virt:{:s}  phys:{:s}".format(
+            page_str, size_str, virt_str, phys_str,
+        ))
+        return
+
+    def buddy_contains(self):
+        used_address_color = Config.get_gef_setting("theme.heap_chunk_address_used")
+        PAGE_SIZE = KernelAddressHeuristicFinder.consts().PAGE_SIZE
+        PAGE_SHIFT = KernelAddressHeuristicFinder.consts().PAGE_SHIFT
+
+        ret = self.resolve_target()
+        if ret is None:
+            return
+
+        page, virt, phys, offset_in_page = ret
+        pfn = phys >> PAGE_SHIFT
+
+        self.quiet_print("page: {:#x}".format(page))
+        if virt is not None:
+            self.quiet_print("virt: {:#x}".format(virt))
+        self.quiet_print("phys: {:#x} (pfn: {:#x})".format(phys, pfn))
+        if offset_in_page:
+            self.quiet_print("remarks: {:s} to page (offset: +{:#x})".format(Color.redify("unaligned"), offset_in_page,))
+
+        # Early test is_page_buddy
+        if self.is_page_buddy(page):
+            head_page = page
+            head_pfn = pfn
+            order = self.get_buddy_order(page)
+        else:
+            head_page, head_pfn, order = self.find_head_page(page, pfn)
+
+        # Not in buddy
+        if head_page is None:
+            self.quiet_print("status: {:s}".format(
+                Color.colorify("unknown", used_address_color),
+            ))
+            gef_print("remarks: no PG_buddy head page found.")
+            gef_print("remarks: the page is in-use, a free pcp page, or a compound tail; "
+                      "a free-list walk is needed to determine which.")
+ 
+        # Part of a larger block
+        elif head_page != page:
+            self.quiet_print("status: {:s}".format(
+                Color.colorify("in buddy (part of a larger block)", "bold green"),
+            ))
+            self.print_block_info(page, pfn, head_page, head_pfn, order)
+            gef_print("remarks: this page is page[{:d}] of the block, +{:#x} bytes from base".format(
+                pfn - head_pfn, (pfn - head_pfn) * PAGE_SIZE,
+            ))
+            if virt is not None:
+                gef_print("remarks: target offset from block base: +{:#x}".format(
+                    (pfn - head_pfn) * PAGE_SIZE + offset_in_page,
+                ))
+ 
+        # Present in the buddy and it's the head of the block
+        else:
+            self.quiet_print("status: {:s}".format(
+                Color.colorify("in buddy (head page)", "bold green"),
+            ))
+            self.print_block_info(page, pfn, head_page, head_pfn, order)
+        return
+
+    @parse_args
+    @only_if_gdb_running
+    @only_if_specific_gdb_mode(mode=("qemu-system", "vmware", "kgdb"))
+    @only_if_specific_arch(arch=("x86_32", "x86_64", "ARM32", "ARM64"))
+    @only_if_in_kernel_or_kpti_disabled
+    def do_invoke(self, args):
+        kversion = Kernel.kernel_version()
+        # will change later depending on the method
+        if kversion < "4.18":
+            self.quiet_err("Unsupported before v3.1")
+            return
+
+        # TODO: Add me later
+        # if self.args.use_physmap:
+            # if not (is_x86_64() or is_arm64()):
+                # self.quiet_err("Unsupported architecture")
+                # return
+
+        # parse args
+        if args.rescan:
+            self.initialized = False
+
+        self.fill_dump_args()
+        self.quiet_info("Wait for memory scan")
+        if not self.initialize():
+            self.quiet_err("Failed to initialize")
+            return
+ 
+        self.sizeof_struct_page = KernelAddressHeuristicFinder.consts().sizeof_struct_page
+        if self.sizeof_struct_page is None: 
+            err("Could not find sizeof(struct page)")
+            return 
+
+        self.buddy_contains()
+        return
+ 
 @register_command
 class KernelPipeCommand(GenericCommand, BufferingOutput):
     """Dump pipe information."""
@@ -151182,7 +151404,8 @@ class PageInfoCommand(GenericCommand):
             flags_str = flags_dic.get(type_value, "none")
         return flags_str
 
-    def u32_to_s32(self, val):
+    @staticmethod
+    def u32_to_s32(val):
         val &= 0xffffffff
         if val & 0x80000000:
             return val - 0x100000000
@@ -151204,15 +151427,16 @@ class PageInfoCommand(GenericCommand):
             return head_page
         return None
 
-    def get_slot6_kind(self, slot6_raw):
-        slot6_s32 = self.u32_to_s32(slot6_raw)
+    @staticmethod
+    def get_slot6_kind(slot6_raw):
+        slot6_s32 = PageInfoCommand.u32_to_s32(slot6_raw)
         kversion = Kernel.kernel_version()
 
         if kversion >= "6.12":
-            pgty_mapcount_underflow_shifted = self.u32_to_s32(0xff << 24)
+            pgty_mapcount_underflow_shifted = PageInfoCommand.u32_to_s32(0xff << 24)
             has_type = slot6_s32 < pgty_mapcount_underflow_shifted
         elif  kversion >= "6.11":
-            page_mapcount_reserve = self.u32_to_s32(0xffff0000) 
+            page_mapcount_reserve = PageInfoCommand.u32_to_s32(0xffff0000) 
             has_type = slot6_s32 < page_mapcount_reserve
         else:
             page_mapcount_reserve = -128
@@ -151237,7 +151461,8 @@ class PageInfoCommand(GenericCommand):
         userspace_mapped = userspace_mapcount > 0
         return mapcount_raw_s32, userspace_mapcount, userspace_mapped
 
-    def is_buddy_free(self, slot6_raw, slot6_kind):
+    @staticmethod
+    def is_buddy_free(slot6_raw, slot6_kind):
         if slot6_kind != "type":
             return False
         kversion = Kernel.kernel_version()

--- a/gef.py
+++ b/gef.py
@@ -127388,22 +127388,39 @@ class BuddyContainsCommand(BuddyDumpCommand):
     parser.add_argument("address", metavar="ADDRESS", type=AddressUtil.parse_address, help="target address.")
     parser.add_argument("-p", "--page", action="store_true",
                         help="interpret ADDRESS as a `struct page` address instead of a virtual address.")
+    parser.add_argument("-L", "--skip-free-list", action="store_true",
+                        help="do not walk the free lists use struct page metadata only. "
+                             "pcp free pages and zone/mtype/cpu cannot be reported in this mode.")
+    parser.add_argument("-Q", "--skip-phys", action="store_true", help="skip virt -> phys translation.")
+    parser.add_argument("-M", "--use-physmap", action="store_true",
+                        help="use physmap for virt -> phys translation (x64/arm64 only).")
     parser.add_argument("--MIGRATE_PCPTYPES", type=int, choices=[3, 4], default=3,
                         help="use specify value; linux: 3, android: 4 (2023~).")
     parser.add_argument("-r", "--rescan", action="store_true", help="do not use cache.")
-    parser.add_argument("-v", "--verbose", action="store_true", help="enable verbose mode.")
     parser.add_argument("-q", "--quiet", action="store_true", help="show result only.")
     _syntax_ = parser.format_help()
 
+    _note_ = [
+        "Given an address, resolves which buddy allocator block contains it.",
+        "",
+        "A free block of order N is described by its head page only, page->private holds the",
+        "order and PG_buddy is set on the head, while the tail pages carry neither. So a page",
+        "that was merged into a higher order block cannot be identified from its own struct",
+        "",
+        "Two modes:",
+        "  default        : walk the free lists like buddy-dump and locate the block.",
+        "  -L             : read struct page flags only but cannot report pcp free pages,",
+    ]
+    _note_ = "\n".join(_note_)
+
     _example_ = [
-        "{0:s} 0xffff888003c01234",
-        "{0:s} -p 0xffffea00000f0040    # ADDRESS is a `struct page`",
+        "{0:s} 0xffff96a7c2144000",
+        "{0:s} -p 0xffffca7640004040    # ADDRESS is a struct page",
+        "{0:s} -L 0xffff96a7c2144000    # Skip free lists",
     ]
     _example_ = "\n".join(_example_).format(_cmdline_)
-    
-    _note_ = "TEST BUDDY CONTAINS"
 
-    def fill_dump_args(self):
+    def fill_buddy_dump_args(self):
         self.args.zone_filter = None
         self.args.order_filter = None
         self.args.mtype_filter = None
@@ -127424,20 +127441,30 @@ class BuddyContainsCommand(BuddyDumpCommand):
             return int(r.group(1), 16)
         return None
 
-    def resolve_target(self):
+    def get_page(self):
         if self.args.page:
             page = self.args.address
             if not is_valid_addr(page):
                 self.quiet_err("Invalid page address")
                 return None
-            virt = Kernel.page2virt(page)
-            offset = 0
         else:
             virt = self.args.address
             page = Kernel.virt2page(virt & get_pagesize_mask_high())
             if page is None:
                 self.quiet_err("Failed to resolve page from virt")
                 return None
+        return page
+
+    def resolve_target(self):
+        page = self.get_page()
+        if page is None:
+            return None
+
+        if self.args.page:
+            virt = self.args.address
+            offset = 0
+        else:
+            virt = Kernel.page2virt(page)
             offset = virt & get_pagesize_mask_low()
         
         phys = self.page2phys_wrapper(page)
@@ -127471,7 +127498,7 @@ class BuddyContainsCommand(BuddyDumpCommand):
             head_pfn = pfn & ~((1 << order) - 1)
             head_page = page - (pfn - head_pfn) * self.sizeof_struct_page
 
-            # Just for good measures 
+            # Just for good measures
             if not is_valid_addr(head_page):
                 continue
             if not self.is_page_buddy(head_page):
@@ -127481,8 +127508,7 @@ class BuddyContainsCommand(BuddyDumpCommand):
             return head_page, head_pfn, order
         return None, None, None
 
-    def print_block_info(self, page, pfn, head_page, head_pfn, order):
-        """Print the block a page belongs to, following buddy-dump's Entry style."""
+    def print_block_info(self, head_page, head_pfn, order):
         chunk_size_color = Config.get_gef_setting("theme.heap_chunk_size")
         freed_address_color = Config.get_gef_setting("theme.heap_chunk_address_freed")
         PAGE_SIZE = KernelAddressHeuristicFinder.consts().PAGE_SIZE
@@ -127506,17 +127532,9 @@ class BuddyContainsCommand(BuddyDumpCommand):
         ))
         return
 
-    def buddy_contains(self):
+    def parse_page(self, page, pfn, phys, virt, offset_in_page):
         used_address_color = Config.get_gef_setting("theme.heap_chunk_address_used")
         PAGE_SIZE = KernelAddressHeuristicFinder.consts().PAGE_SIZE
-        PAGE_SHIFT = KernelAddressHeuristicFinder.consts().PAGE_SHIFT
-
-        ret = self.resolve_target()
-        if ret is None:
-            return
-
-        page, virt, phys, offset_in_page = ret
-        pfn = phys >> PAGE_SHIFT
 
         self.quiet_print("page: {:#x}".format(page))
         if virt is not None:
@@ -127524,8 +127542,7 @@ class BuddyContainsCommand(BuddyDumpCommand):
         self.quiet_print("phys: {:#x} (pfn: {:#x})".format(phys, pfn))
         if offset_in_page:
             self.quiet_print("remarks: {:s} to page (offset: +{:#x})".format(Color.redify("unaligned"), offset_in_page,))
-
-        # Early test is_page_buddy
+        
         if self.is_page_buddy(page):
             head_page = page
             head_pfn = pfn
@@ -127533,35 +127550,140 @@ class BuddyContainsCommand(BuddyDumpCommand):
         else:
             head_page, head_pfn, order = self.find_head_page(page, pfn)
 
-        # Not in buddy
+        # Not in buddy ?
         if head_page is None:
             self.quiet_print("status: {:s}".format(
                 Color.colorify("unknown", used_address_color),
             ))
-            gef_print("remarks: no PG_buddy head page found.")
-            gef_print("remarks: the page is in-use, a free pcp page, or a compound tail; "
-                      "a free-list walk is needed to determine which.")
+            gef_print("remarks: no PG_buddy head page found, run buddy-contains without skipping free lists.")
  
         # Part of a larger block
         elif head_page != page:
             self.quiet_print("status: {:s}".format(
                 Color.colorify("in buddy (part of a larger block)", "bold green"),
             ))
-            self.print_block_info(page, pfn, head_page, head_pfn, order)
+            self.print_block_info(head_page, head_pfn, order)
             gef_print("remarks: this page is page[{:d}] of the block, +{:#x} bytes from base".format(
                 pfn - head_pfn, (pfn - head_pfn) * PAGE_SIZE,
             ))
-            if virt is not None:
-                gef_print("remarks: target offset from block base: +{:#x}".format(
-                    (pfn - head_pfn) * PAGE_SIZE + offset_in_page,
-                ))
- 
+
         # Present in the buddy and it's the head of the block
         else:
             self.quiet_print("status: {:s}".format(
                 Color.colorify("in buddy (head page)", "bold green"),
             ))
-            self.print_block_info(page, pfn, head_page, head_pfn, order)
+            self.print_block_info(head_page, head_pfn, order)
+
+        return
+
+    def get_lists(self, page):
+        if not self.args.skip_phys and not self.args.use_physmap:
+            BuddyDumpCommand.maps = PageMap.get_page_maps(None)
+            if BuddyDumpCommand.maps is None:
+                return None
+ 
+        node_entries = []
+        tqdm = GefUtil.get_tqdm(not self.args.quiet)
+        for i, node in tqdm(enumerate(self.nodes), leave=False, total=len(self.nodes), desc="node"):
+            title = "node[{:d}] @ {:#x}".format(i, node)
+            node_entries.append([title, self.dump_node(node)])
+
+        return node_entries
+
+    def find_in_lists(self, node_entries, page):
+        def contains(entry):
+            if entry is None:
+                return False
+            npages = entry.size // KernelAddressHeuristicFinder.consts().PAGE_SIZE
+            return entry.page <= page < entry.page + npages * self.sizeof_struct_page
+ 
+        for node_title, zone_entries in node_entries:
+            for zone_title, zone_entry in zone_entries:
+                if "per_cpu_pageset" in zone_entry:
+                    for cpu_num, pcp_all_entries in zone_entry["per_cpu_pageset"].items():
+                        for pcp_title, pcp_entries, has_any in pcp_all_entries:
+                            if not has_any:
+                                continue
+                            for entry in pcp_entries:
+                                if contains(entry):
+                                    return {
+                                        "kind": "pcp",
+                                        "entry": entry,
+                                        "node_title": node_title,
+                                        "zone_title": zone_title,
+                                        "section_title": "per_cpu_pageset",
+                                        "sub_title": "cpu: {:d}".format(cpu_num),
+                                        "list_title": pcp_title,
+                                    }
+                                    
+ 
+                if "free_area" in zone_entry:
+                    for order_title, free_lists, has_any in zone_entry["free_area"]:
+                        if not has_any:
+                            continue
+                        for mtype_title, free_list, has_any2 in free_lists:
+                            if not has_any2:
+                                continue
+                            for entry in free_list:
+                                if contains(entry):
+                                    return {
+                                        "kind": "free_area",
+                                        "entry": entry,
+                                        "node_title": node_title,
+                                        "zone_title": zone_title,
+                                        "section_title": "free_area",
+                                        "sub_title": order_title,
+                                        "list_title": mtype_title,
+                                    }
+        return None
+
+    def parse_free_lists(self, page):
+        used_address_color = Config.get_gef_setting("theme.heap_chunk_address_used")
+        PAGE_SIZE = KernelAddressHeuristicFinder.consts().PAGE_SIZE
+
+        lists = self.get_lists(page)
+        if lists is None:
+            self.quiet_err("Failed to resolve maps")
+            return
+
+        found = self.find_in_lists(lists, page)
+
+        if found is None:
+            self.quiet_print("status: {:s}".format(Color.colorify("in-use", used_address_color)))
+            gef_print("remarks: not found in any free_area or pcp list.")
+            return
+
+        entry = found["entry"]
+        gef_print(titlify(found["node_title"]))
+        gef_print(titlify(found["zone_title"]))
+        gef_print(titlify(found["section_title"]))
+        gef_print(found["sub_title"])
+        gef_print(found["list_title"])
+        gef_print(str(entry).rstrip())
+
+        if entry.page != page:
+            index = (page - entry.page) // self.sizeof_struct_page
+            gef_print("remarks: this page is page[{:d}] of the block, +{:#x} bytes from base".format(
+                index, index * PAGE_SIZE,
+            ))
+        return
+
+    def buddy_contains(self):
+        PAGE_SHIFT = KernelAddressHeuristicFinder.consts().PAGE_SHIFT
+
+        if self.args.skip_free_list:
+            ret = self.resolve_target()
+            if ret is None:
+                return
+            page, virt, phys, offset_in_page = ret
+            pfn = phys >> PAGE_SHIFT
+            self.parse_page(page, pfn, phys, virt, offset_in_page)
+        else:
+            page = self.get_page()
+            if page is None:
+                return 
+            self.parse_free_lists(page)
+
         return
 
     @parse_args
@@ -127571,22 +127693,28 @@ class BuddyContainsCommand(BuddyDumpCommand):
     @only_if_in_kernel_or_kpti_disabled
     def do_invoke(self, args):
         kversion = Kernel.kernel_version()
-        # will change later depending on the method
-        if kversion < "4.18":
+
+        if self.args.skip_free_list and kversion < "4.18":
+            self.quiet_err("Unsupported before v4.18")
+            return
+        
+        if kversion < "3.1":
             self.quiet_err("Unsupported before v3.1")
             return
 
-        # TODO: Add me later
-        # if self.args.use_physmap:
-            # if not (is_x86_64() or is_arm64()):
-                # self.quiet_err("Unsupported architecture")
-                # return
+        if self.args.skip_free_list and (self.args.skip_phys or self.args.use_physmap):
+            self.quiet_warn("options -Q/-M are ignored with -L")
 
-        # parse args
+        if self.args.use_physmap:
+            if not (is_x86_64() or is_arm64()):
+                self.quiet_err("Unsupported architecture")
+                return
+
+            # parse args
         if args.rescan:
             self.initialized = False
 
-        self.fill_dump_args()
+        self.fill_buddy_dump_args()
         self.quiet_info("Wait for memory scan")
         if not self.initialize():
             self.quiet_err("Failed to initialize")
@@ -127594,7 +127722,7 @@ class BuddyContainsCommand(BuddyDumpCommand):
  
         self.sizeof_struct_page = KernelAddressHeuristicFinder.consts().sizeof_struct_page
         if self.sizeof_struct_page is None: 
-            err("Could not find sizeof(struct page)")
+            self.quiet_err("Could not find sizeof(struct page)")
             return 
 
         self.buddy_contains()


### PR DESCRIPTION
Hey,

When dealing with cross cache related attacks i've more than once found myself parsing the output of `buddy-dump`, so what i usually do is run `pageinfo` on the page i'm interested in. However, if said page is in the PCP or has been merged into a block of order > 0, the `struct page` will not have the `PG_BUDDY` flag set, therefore i made this command in the same spirit as `slab-contains`.

The default mode parses the free-lists just like `buddy-dump` to find out if a given page is in the buddy or not.
One can use the `-L` option to skip the free-lists parsing, this mode only uses flags present in `struct page` it can detect whether a page is in the middle of a buddy block but it cannot find out if a page is in the PCP or not. 

this is quite useful for me, i don't know if people would like to use it too.
If something needs refactoring or modifications i would be happy to do so.

<img width="1346" height="880" alt="PR" src="https://github.com/user-attachments/assets/8b1d97f6-f136-4f07-b074-3edf44589faa" />
